### PR TITLE
C preprocessor colors improvement

### DIFF
--- a/web_src/less/chroma/light.less
+++ b/web_src/less/chroma/light.less
@@ -53,8 +53,8 @@
 .chroma .cm { color: #999988; } /* CommentMultiline */
 .chroma .c1 { color: #6a737d; } /* CommentSingle */
 .chroma .cs { color: #999999; } /* CommentSpecial */
-.chroma .cp { color: #999999; } /* CommentPreproc */
-.chroma .cpf { color: #999999; } /* CommentPreprocFile */
+.chroma .cp { color: #109295 } /* CommentPreproc */
+.chroma .cpf { color: #4C4DBC; } /* CommentPreprocFile */
 .chroma .gd { color: #000000; background-color: #ffdddd; } /* GenericDeleted */
 .chroma .ge { color: #000000; } /* GenericEmph */
 .chroma .gr { color: #aa0000; } /* GenericError */

--- a/web_src/less/chroma/light.less
+++ b/web_src/less/chroma/light.less
@@ -54,7 +54,7 @@
 .chroma .c1 { color: #6a737d; } /* CommentSingle */
 .chroma .cs { color: #999999; } /* CommentSpecial */
 .chroma .cp { color: #109295 } /* CommentPreproc */
-.chroma .cpf { color: #4C4DBC; } /* CommentPreprocFile */
+.chroma .cpf { color: #4c4dbc; } /* CommentPreprocFile */
 .chroma .gd { color: #000000; background-color: #ffdddd; } /* GenericDeleted */
 .chroma .ge { color: #000000; } /* GenericEmph */
 .chroma .gr { color: #aa0000; } /* GenericError */


### PR DESCRIPTION
Fixes #18670

C comments and preprocessor had nearly-same colors in light theme.
Old values:
```
.chroma .cm { color: #999988; } /* CommentMultiline */
.chroma .cp { color: #999999; } /* CommentPreproc */
.chroma .cpf { color: #999999; } /* CommentPreprocFile */
```
Proposed values:
```
.chroma .cp { color: #109295 } /* CommentPreproc */
.chroma .cpf { color: #4C4DBC; } /* CommentPreprocFile */
```
